### PR TITLE
rate limiting based on http_x_forwarded_for

### DIFF
--- a/conf.d/enable-rate-limits.conf
+++ b/conf.d/enable-rate-limits.conf
@@ -1,4 +1,4 @@
-limit_req_zone $binary_remote_addr zone=perip:10m rate=10r/s;
+limit_req_zone $http_x_forwarded_for zone=perip:10m rate=10r/s;
 limit_req_zone $server_name zone=perserver:10m rate=100r/s;
-limit_req_zone $binary_remote_addr zone=faucet:10m rate=1r/m;
+limit_req_zone $http_x_forwarded_for zone=faucet:10m rate=1r/m;
 limit_req_log_level notice;


### PR DESCRIPTION
Requests to archive nodes are proxied through Cloudflare, so the remote_addr will always be from Cloudflare. This means that valid requests proxied from the same Cloudflare IP could be rate limitted.

```
{"msec": "1623172488.937", "connection": "352917", "connection_requests": "1", "pid": "16", "request_id": "eebe25c81765769a484bf190c0849c83", "request_length": "845", "remote_addr": "162.158.94.179", "remote_user": "", "remote_port": "57942", "time_local": "08/Jun/2021:17:14:48 +0000", "time_iso8601": "2021-06-08T17:14:48+00:00", "request": "POST /rpc HTTP/1.1", "request_uri": "/rpc", "args": "", "status": "200", "body_bytes_sent": "135", "bytes_sent": "547", "http_referer": "", "http_user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) radix-olympia-desktop-wallet/0.6.2 Chrome/89.0.4389.90 Electron/12.0.2 Safari/537.36", "http_x_forwarded_for": "5.146.194.169", "http_host": "releasenet.radixdlt.com", "server_name": "localhost", "request_time": "0.000", "upstream": "172.28.0.2:8080", "upstream_connect_time": "0.000", "upstream_header_time": "0.000", "upstream_response_time": "0.000", "upstream_response_length": "135", "upstream_cache_status": "", "ssl_protocol": "TLSv1.2", "ssl_cipher": "ECDHE-RSA-AES256-GCM-SHA384", "scheme": "https", "request_method": "POST", "server_protocol": "HTTP/1.1", "pipe": ".", "gzip_ratio": "", "http_cf_ray": "65c3c2357a754a68-FRA"}
```